### PR TITLE
feat(hashing): Allow sha1 in addition to MD5

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ key.setNotch('fields', ['occupation', 'name', 'birthday'], true);
 
 ## API
 
+* `constructor(algo = 'sha1')`
+   * algo – the hashing algorithm to use when creating the key, defaults
+     to `sha1`. Possible options: `sha1`, `MD5`.
 * `resetKey()` - Removes all notches from the key.
 * `setNotch(id, notch[, sort, [comparator]])` - Adds a notch to the key or
   replaces an existing notch.

--- a/lib/key.js
+++ b/lib/key.js
@@ -1,5 +1,5 @@
 'use strict';
-const { MD5 } = require('object-hash');
+const { sha1, MD5 } = require('object-hash');
 
 /**
  * @class
@@ -7,9 +7,17 @@ const { MD5 } = require('object-hash');
 class SkeletonKey {
   /**
    * @constructor
+   *
+   * @param {string} algo
+   *   The hashing algorithm to use, MD5 or sha1. Defaults to sha1.
    */
-  constructor() {
+  constructor(algo = 'sha1') {
+    if (algo !== 'sha1' && algo !== 'MD5') {
+      throw new Error('Hash algorithm must be sha1 or MD5');
+    }
+
     this.key = new Map();
+    this.algo = algo;
   }
 
   /**
@@ -79,7 +87,10 @@ class SkeletonKey {
    *   The hashed representation of the key.
    */
   cut() {
-    return MD5(this.key); // eslint-disable-line new-cap
+    if (this.algo === 'MD5') {
+      return MD5(this.key); // eslint-disable-line new-cap
+    }
+    return sha1(this.key); // eslint-disable-line new-cap
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,11 @@ module.exports = {
     this.key = new SkeletonKey();
     cb();
   },
+  invalidAlgo(test) {
+    test.expect(1);
+    test.throws(() => new SkeletonKey('junk'), 'Invalid algorithm did not throw.');
+    test.done();
+  },
   resetKey(test) {
     test.expect(1);
     this.key.setNotch('test', 'test');
@@ -47,27 +52,57 @@ module.exports = {
     test.done();
   },
   cut: {
-    simple(test) {
-      test.expect(1);
-      this.key.setNotch('test', 'test');
-      test.equal('1b8d136b7e8c2abd66fb08f6b115b62e', this.key.cut(), 'Unexpected hash.');
-      test.done();
+    md5: {
+      setUp(cb) {
+        this.key = new SkeletonKey('MD5');
+        cb();
+      },
+      simple(test) {
+        test.expect(1);
+        this.key.setNotch('test', 'test');
+        test.equal('1b8d136b7e8c2abd66fb08f6b115b62e', this.key.cut(), 'Unexpected hash.');
+        test.done();
+      },
+      withObjects(test) {
+        test.expect(2);
+        this.key.setNotch('test', { a: 1, b: 2 });
+        test.equal('a423fe10cbb06863a07d44ac5d2168df', this.key.cut(), 'Unexpected hash.');
+        this.key.setNotch('test', { b: 2, a: 1 });
+        test.equal('a423fe10cbb06863a07d44ac5d2168df', this.key.cut(), 'Unexpected hash.');
+        test.done();
+      },
+      withSortedArrays(test) {
+        test.expect(2);
+        this.key.setNotch('test', [1, 2, 3]);
+        test.equal('21c354dd04e7aac0afc8e3e3693bba80', this.key.cut(), 'Unexpected hash.');
+        this.key.setNotch('test', [3, 2, 1], true);
+        test.equal('21c354dd04e7aac0afc8e3e3693bba80', this.key.cut(), 'Unexpected hash.');
+        test.done();
+      },
     },
-    withObjects(test) {
-      test.expect(2);
-      this.key.setNotch('test', { a: 1, b: 2 });
-      test.equal('a423fe10cbb06863a07d44ac5d2168df', this.key.cut(), 'Unexpected hash.');
-      this.key.setNotch('test', { b: 2, a: 1 });
-      test.equal('a423fe10cbb06863a07d44ac5d2168df', this.key.cut(), 'Unexpected hash.');
-      test.done();
-    },
-    withSortedArrays(test) {
-      test.expect(2);
-      this.key.setNotch('test', [1, 2, 3]);
-      test.equal('21c354dd04e7aac0afc8e3e3693bba80', this.key.cut(), 'Unexpected hash.');
-      this.key.setNotch('test', [3, 2, 1], true);
-      test.equal('21c354dd04e7aac0afc8e3e3693bba80', this.key.cut(), 'Unexpected hash.');
-      test.done();
+    sha1: {
+      simple(test) {
+        test.expect(1);
+        this.key.setNotch('test', 'test');
+        test.equal('7d3f2d06db1886a07d65c4f4301bf2e677a1d79d', this.key.cut(), 'Unexpected hash.');
+        test.done();
+      },
+      withObjects(test) {
+        test.expect(2);
+        this.key.setNotch('test', { a: 1, b: 2 });
+        test.equal('90a2ea7a92789cb4100fb704513a3748918495f7', this.key.cut(), 'Unexpected hash.');
+        this.key.setNotch('test', { b: 2, a: 1 });
+        test.equal('90a2ea7a92789cb4100fb704513a3748918495f7', this.key.cut(), 'Unexpected hash.');
+        test.done();
+      },
+      withSortedArrays(test) {
+        test.expect(2);
+        this.key.setNotch('test', [1, 2, 3]);
+        test.equal('4ad0e47555126079c97876aebd385b43b7059610', this.key.cut(), 'Unexpected hash.');
+        this.key.setNotch('test', [3, 2, 1], true);
+        test.equal('4ad0e47555126079c97876aebd385b43b7059610', this.key.cut(), 'Unexpected hash.');
+        test.done();
+      },
     },
   },
 };


### PR DESCRIPTION
BREAKING CHANGE: This will set sha1 to the dfault hash algorithm which in itself is not breaking but will result in different keys unless you instantiate the module like this:

```javascript
sk = new SkeletonKey('MD5');
```